### PR TITLE
[0.7.1] - Clean-Install Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ Format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [0.7.1] — 2026-08-17 — Clean-Install Fixes
+
+A fix release for three things a clean install surfaces that a development
+machine cannot: a build path that had never been compiled, a graph colour that
+only looked right locally, and a test coupled to one engine's log wording.
+
+### Fixes
+
+- **The editor module builds without Electronic Nodes installed.** The
+  `WITH_ELECTRONIC_NODES` guard was defined only when the optional plugin was
+  found, leaving it undefined rather than zero everywhere else — a warning on
+  some engine versions and a hard error on others. A project without Electronic
+  Nodes could fail to compile. The definition is now unconditional, and only its
+  value varies with whether the plugin is present.
+- **Prerequisite wires are distinct from activation wires on a fresh install.**
+  The shipped default for the prerequisite wire colour matched the activation
+  wire colour, so the two wire types — execution flow and gating contingency —
+  rendered identically until the dashed-wire integration was active or the
+  colour was overridden locally.
+- **A resolver test no longer depends on one engine's log formatting.** It
+  asserted on the exact wording of a failed class lookup, which varies between
+  engine versions; it now matches the stable portion.
+
 ## [0.7.0] — 2026-08-17 — The Data Resolver
 
 Quest data has always lived inside the `.uasset` binary. That's fine while

--- a/Plugins/SimpleCore/SimpleCore.uplugin
+++ b/Plugins/SimpleCore/SimpleCore.uplugin
@@ -1,7 +1,7 @@
 ﻿{
     "FileVersion": 3,
     "Version": 1,
-    "VersionName": "0.7.0",
+    "VersionName": "0.7.1",
     "FriendlyName": "Simple Core",
     "Description": "Lightweight signal bus and world state coordination layer. Foundation for the Simple suite of plugins.",
     "Category": "Gameplay",

--- a/Plugins/SimpleQuest/SimpleQuest.uplugin
+++ b/Plugins/SimpleQuest/SimpleQuest.uplugin
@@ -1,7 +1,7 @@
 {
 	"FileVersion": 3,
 	"Version": 1,
-	"VersionName": "0.7.0",
+	"VersionName": "0.7.1",
 	"FriendlyName": "Simple Quest",
 	"Description": "Easily create and manage any series of linear or non-linear gameplay events - or quests.",
 	"Category": "Gameplay",

--- a/Plugins/SimpleQuest/Source/SimpleQuestEditor/Private/Tests/QuestResolverMappingTests.cpp
+++ b/Plugins/SimpleQuest/Source/SimpleQuestEditor/Private/Tests/QuestResolverMappingTests.cpp
@@ -1035,8 +1035,10 @@ bool FQuestResolver_PlanRefusesUndeliverableRows::RunTest(const FString& Paramet
 {
 	// Resolving a deliberately-bogus class exhausts every lookup before refusing, and the engine narrates each miss. Declare
 	// both so the run stays clean AND the exhaustion is asserted — a refusal that skipped the lookup would be a different bug.
+	// The second match deliberately stops before the class name: engines differ on whether a failed lookup is narrated with a
+	// package prefix ("Class None.X" vs "Class X"), and the name itself is already pinned by the line above.
 	AddExpectedMessagePlain(TEXT("Short type name \"NoSuchNodeClass\" provided for TryFindType"), EAutomationExpectedMessageFlags::Contains, 1);
-	AddExpectedMessagePlain(TEXT("Failed to find object 'Class None.NoSuchNodeClass'"), EAutomationExpectedMessageFlags::Contains, 1);
+	AddExpectedMessagePlain(TEXT("Failed to find object 'Class"), EAutomationExpectedMessageFlags::Contains, 1);
 	
 	// A plan is a promise the apply step keeps. Promising to CREATE a node whose class does not resolve, or one whose level
 	// nothing declares, is a promise the spawn path refuses — so the plan would report work that silently never happens, and

--- a/Plugins/SimpleQuest/Source/SimpleQuestEditor/Public/Settings/SimpleQuestEditorVisualSettings.h
+++ b/Plugins/SimpleQuest/Source/SimpleQuestEditor/Public/Settings/SimpleQuestEditorVisualSettings.h
@@ -13,9 +13,7 @@
  * colors, and debug-highlight colors used by the Questline graph editor. Per-developer (saved to the user's local
  * EditorPerProjectUserSettings.ini, not source-controlled); class-header defaults are the canonical palette that ships
  * with the plugin. Lives in Editor Preferences rather than Project Settings because these knobs aren't meant for adopter
- * tweaking — the palette is a categorization vocabulary the plugin standardizes on.
- *
- * TO BE REMOVED ONCE THE COLOR SCHEME IS FINALIZED
+ * tweaking — the palette is a categorization vocabulary the plugin standardizes on. 
  */
 UCLASS(config=EditorPerProjectUserSettings, meta=(DisplayName="Simple Quest Visuals"))
 class SIMPLEQUESTEDITOR_API USimpleQuestEditorVisualSettings : public UDeveloperSettings
@@ -32,7 +30,7 @@ public:
 	FLinearColor ActivationWireColor = FLinearColor::White;
 
 	UPROPERTY(Config, EditAnywhere, Category="Wires")
-	FLinearColor PrerequisiteWireColor = FLinearColor::White;
+	FLinearColor PrerequisiteWireColor = FLinearColor(0.603212f, 0.128689f, 0.651406f);
 
 	UPROPERTY(Config, EditAnywhere, Category="Wires")
 	FLinearColor OutcomeWireColor = FLinearColor(1.000000f, 0.734210f, 0.061106f);

--- a/Plugins/SimpleQuest/Source/SimpleQuestEditorEN/SimpleQuestEditorEN.Build.cs
+++ b/Plugins/SimpleQuest/Source/SimpleQuestEditorEN/SimpleQuestEditorEN.Build.cs
@@ -24,24 +24,30 @@ public class SimpleQuestEditorEN : ModuleRules
             "SimpleQuestEditor"
         });
     
-        // EN integration requires UE 5.7+ — the MakeDrawSpline virtual hook needed for the prereq-wire dash effect
-        // was introduced in the Electronic Nodes release for UE 5.7. Stock 5.6 EN doesn't expose hooks at the 
-        // abstraction layer the integration needs, so on pre-5.7 engines we skip the integration entirely
-        // (the module still compiles; the #if-guarded source files just compile to empty translation units). The
-        // rest of the SimpleQuest plugin works fine on 5.6 — only the optional EN visual layer is gated.
+        // EN integration requires UE 5.7+ - the MakeDrawSpline virtual hook needed for the prereq-wire dash effect
+        // was introduced in the Electronic Nodes release for UE 5.7. Stock 5.6 EN doesn't expose hooks at the
+        // abstraction layer the integration needs, so on pre-5.7 engines, or wherever Electronic Nodes simply isn't
+        // installed, the integration is skipped: WITH_ELECTRONIC_NODES is defined to 0 and the guarded source files
+        // compile to empty translation units. The rest of the SimpleQuest plugin is unaffected either way.
+        // The definition is UNCONDITIONAL and only its value varies - an undefined macro under #if is a hard error
+        // on newer engines, so leaving it undefined on the skip path would break the build rather than disable a feature.
         bool bEngineSupportsENIntegration =
             Target.Version.MajorVersion > 5 ||
             (Target.Version.MajorVersion == 5 && Target.Version.MinorVersion >= 7);
-    
+
         string EngineDir = Path.GetFullPath(Target.RelativeEnginePath);
-    
-        if (bEngineSupportsENIntegration &&
-            FindElectronicNodes(EngineDir, ModuleDirectory, Target, out string ENSourceDir))
+        string ENSourceDir = "";
+
+        bool bWithElectronicNodes = bEngineSupportsENIntegration &&
+            FindElectronicNodes(EngineDir, ModuleDirectory, Target, out ENSourceDir);
+
+        if (bWithElectronicNodes)
         {
             PrivateDependencyModuleNames.Add("ElectronicNodes");
             PrivateIncludePaths.Add(Path.Combine(ENSourceDir, "Private"));
-            PrivateDefinitions.Add("WITH_ELECTRONIC_NODES=1");
         }
+
+        PrivateDefinitions.Add("WITH_ELECTRONIC_NODES=" + (bWithElectronicNodes ? "1" : "0"));
     }
 
     static bool FindElectronicNodes(string EngineDir, string ModuleDir, ReadOnlyTargetRules Target, out string ENSourceDir)


### PR DESCRIPTION
## [0.7.1] — 2026-08-17 — Clean-Install Fixes

A fix release for three things a clean install surfaces that a development
machine cannot: a build path that had never been compiled, a graph color that
only looked right locally, and a test coupled to one engine's log wording.

### Fixes

- **The editor module builds without Electronic Nodes installed.** The
  `WITH_ELECTRONIC_NODES` guard was defined only when the optional plugin was
  found, leaving it undefined rather than zero everywhere else — a warning on
  some engine versions and a hard error on others. A project without Electronic
  Nodes could fail to compile. The definition is now unconditional, and only its
  value varies with whether the plugin is present.
- **Prerequisite wires are distinct from activation wires on a fresh install.**
  The shipped default for the prerequisite wire color matched the activation
  wire color, so the two wire types — execution flow and gating contingency —
  rendered identically until the dashed-wire integration was active or the
  color was overridden locally.
- **A resolver test no longer depends on one engine's log formatting.** It
  asserted on the exact wording of a failed class lookup, which varies between
  engine versions; it now matches the stable portion.